### PR TITLE
Fix rustup installation command to avoid pipe failures on some shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ npm install -g deno
 
 Install rust
 
-```
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/rustup-init.sh
+chmod +x /tmp/rustup-init.sh
+/tmp/rustup-init.sh -y
+source "$HOME/.cargo/env"
 ```


### PR DESCRIPTION
Before:
<img width="616" height="45" alt="image" src="https://github.com/user-attachments/assets/4ac7b191-cd89-43c8-89ed-85fad70f8224" />

After:
<img width="859" height="631" alt="image" src="https://github.com/user-attachments/assets/4ce77d79-c39d-4143-ac76-1b685ea1962c" />
