### PR TITLE
feat(markdown): add underline token handlers for HTML serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 .deno
 .vite
 .playwright-mcp
+.DS_Store

--- a/packages/extension-markdown/src/token_handlers/inline_token_handlers.ts
+++ b/packages/extension-markdown/src/token_handlers/inline_token_handlers.ts
@@ -342,6 +342,18 @@ export function getHtmlInlineTokensHandlers(): Record<
         ctx.current.log(`</${tag}>`, token);
       },
     ],
+    'underline_open': [
+      (token: Token, ctx: ContextStash) => {
+        const tag = token.tag || 'u';
+        ctx.current.log(`<${tag}>`, token);
+      },
+    ],
+    'underline_close': [
+      (token: Token, ctx: ContextStash) => {
+        const tag = token.tag || 'u';
+        ctx.current.log(`</${tag}>`, token);
+      },
+    ],
 
     'link_open': [
       (token: Token, ctx: ContextStash) => {


### PR DESCRIPTION
feat(markdown): add underline token handlers for HTML serialization

Adds underline_open and underline_close handlers to support underline
formatting in markdown-to-HTML conversion.

Also adds .DS_Store to .gitignore.