### PR TITLE
fix: harden editor and tree-sitter parser for iOS Cordova (WKWebView/JSC)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,12 +17,13 @@ jobs:
         run: |
           echo "Checking commit messages in this PR..."
           INVALID=0
-          for msg in $(git log --pretty=format:"%s" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}); do
+          while IFS= read -r msg; do
+            [ -z "$msg" ] && continue
             if ! echo "$msg" | grep -E "^(feat|fix|chore|docs|test|refactor|ci|build)(\(.+\))?: .+" >/dev/null; then
               echo "::error ::Invalid commit message: '$msg'"
               INVALID=1
             fi
-          done
+          done <<< "$(git log --pretty=format:"%s" ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})"
           if [ $INVALID -eq 1 ]; then
             echo "::notice ::Please squash/fixup your commits and follow the Conventional Commit format:"
             echo "::notice ::<type>(scope): short description"
@@ -46,14 +47,15 @@ jobs:
           )
 
           # Loop through commits
-          for msg in $COMMITS; do
+          while IFS= read -r msg; do
+            [ -z "$msg" ] && continue
             for pattern in "${TRIVIAL_REGEXES[@]}"; do
               if echo "$msg" | grep -Ei "$pattern" >/dev/null; then
                 echo "::error ::Trivial commit detected: '$msg'"
                 INVALID=1
               fi
             done
-          done
+          done <<< "$COMMITS"
 
           if [ $INVALID -eq 1 ]; then
             echo "::notice ::Please squash/fixup trivial commits before merging."

--- a/deno.lock
+++ b/deno.lock
@@ -62,6 +62,7 @@
     "npm:vite-css-modules@latest": "1.12.0_postcss@8.5.15_vite@7.3.1__@types+node@24.2.0__picomatch@4.0.3",
     "npm:vite-plugin-standard-css-modules@latest": "0.0.11_vite@7.1.4__@types+node@24.2.0__picomatch@4.0.3_@types+node@24.2.0",
     "npm:vite-plugin-wasm@3.6.0": "3.6.0_vite@8.1.2__@types+node@24.2.0__esbuild@0.27.2_@types+node@24.2.0_esbuild@0.27.2",
+    "npm:vite@*": "8.1.2_@types+node@24.2.0_esbuild@0.27.2",
     "npm:vite@8.1.2": "8.1.2_@types+node@24.2.0_esbuild@0.27.2",
     "npm:vscode-languageserver-protocol@3.17.5": "3.17.5",
     "npm:vscode-languageserver-textdocument@1.0.12": "1.0.12",

--- a/packages/editor/src/ExtensionManager.ts
+++ b/packages/editor/src/ExtensionManager.ts
@@ -22,14 +22,59 @@ import { TrackSelecionPlugin } from './plugins/TrackSelecionPlugin.ts';
 import * as yaml from './utilities/yaml.ts';
 import { createSearchPlugin } from './search/search.ts';
 
-function splitExtensions(extensions: Iterable<AnyExtension>) {
-  const baseExtensions = Array.from(extensions).filter((extension) =>
+/**
+ * Defensively converts an unknown value into a real array.
+ *
+ * Some runtimes (notably iOS 26.5 / JavaScriptCore inside a Cordova WKWebView)
+ * have been observed to throw `TypeError: {} is not iterable` when a `for...of`
+ * loop or spread is applied to a value that is not a proper array. To stay
+ * resilient we prefer `.forEach` (which does not rely on the iterator protocol)
+ * for Set/Map-like collections, fall back to `Array.from` for other iterables,
+ * and coerce everything else to an empty array while logging a diagnostic so the
+ * offending value can be identified on-device.
+ */
+function toArraySafe<T>(value: unknown, context?: string): T[] {
+  if (Array.isArray(value)) {
+    return value as T[];
+  }
+
+  if (value && typeof (value as { forEach?: unknown }).forEach === 'function') {
+    const out: T[] = [];
+    (value as { forEach: (cb: (item: T) => void) => void }).forEach((item) => {
+      out.push(item);
+    });
+    return out;
+  }
+
+  if (
+    value &&
+    typeof (value as { [Symbol.iterator]?: unknown })[Symbol.iterator] ===
+      'function'
+  ) {
+    return Array.from(value as Iterable<T>);
+  }
+
+  if (context && value !== undefined && value !== null) {
+    console.warn(
+      `[kerebron] ExtensionManager: expected an iterable for ${context}, received ${
+        Object.prototype.toString.call(value)
+      }; using an empty list instead.`,
+      value,
+    );
+  }
+
+  return [];
+}
+
+export function splitExtensions(extensions: Iterable<AnyExtension>) {
+  const all = toArraySafe<AnyExtension>(extensions);
+  const baseExtensions = all.filter((extension) =>
     extension.type === 'extension'
   ) as Extension[];
-  const nodeExtensions = Array.from(extensions).filter((extension) =>
+  const nodeExtensions = all.filter((extension) =>
     extension.type === 'node'
   ) as Node[];
-  const markExtensions = Array.from(extensions).filter((extension) =>
+  const markExtensions = all.filter((extension) =>
     extension.type === 'mark'
   ) as Mark[];
 
@@ -48,9 +93,15 @@ export class ExtensionManager {
   public converters: Record<string, Converter> = {};
 
   constructor(public readonly editorKits: EditorKit[], private debug = false) {
-    const extensions: AnyExtensionOrReq[] = editorKits
+    const extensions: AnyExtensionOrReq[] = toArraySafe<EditorKit>(editorKits)
       .reduce(
-        (prev: AnyExtensionOrReq[], cur) => prev.concat(cur.getExtensions()),
+        (prev: AnyExtensionOrReq[], cur) =>
+          prev.concat(
+            toArraySafe<AnyExtensionOrReq>(
+              cur.getExtensions(),
+              'EditorKit.getExtensions()',
+            ),
+          ),
         [],
       );
 
@@ -175,7 +226,7 @@ export class ExtensionManager {
     const allExtensions = new Map<string, AnyExtensionOrReq>();
 
     const createMap = (extensions: Set<AnyExtensionOrReq>) => {
-      for (const extension of extensions) {
+      extensions.forEach((extension) => {
         if ('name' in extension) {
           const existing = allExtensions.get(extension.name);
           if (
@@ -186,12 +237,13 @@ export class ExtensionManager {
           allExtensions.set(extension.name, extension);
         }
         if ('requires' in extension) {
-          const childExtensions = Array.from(extension.requires).filter((e) =>
-            typeof e !== 'string'
-          );
+          const childExtensions = toArraySafe<AnyExtensionOrReq | string>(
+            extension.requires,
+            `${'name' in extension ? extension.name : 'extension'}.requires`,
+          ).filter((e) => typeof e !== 'string') as AnyExtensionOrReq[];
           createMap(new Set(childExtensions));
         }
-      }
+      });
     };
 
     createMap(extensions);
@@ -211,7 +263,10 @@ export class ExtensionManager {
       }
 
       if ('requires' in extension) {
-        const requires = extension.requires || [];
+        const requires = toArraySafe<AnyExtensionOrReq | string>(
+          extension.requires,
+          `${'name' in extension ? extension.name : 'extension'}.requires`,
+        );
         const requireNames = requires.map((
           e: string | AnyExtensionOrReq,
         ): string => typeof e === 'string' ? e : ('name' in e ? e.name : ''));
@@ -239,14 +294,17 @@ export class ExtensionManager {
       }
     }
 
-    for (const extension of allExtensions.values()) {
+    allExtensions.forEach((extension) => {
       recursiveInitializeExtension(extension);
-    }
+    });
 
     if (allExtensions.size > 0) {
+      const remaining: string[] = [];
+      allExtensions.forEach((_extension, key) => {
+        remaining.push(key);
+      });
       throw new Error(
-        'Not all extensions initialized: ' +
-          Array.from(allExtensions.keys()).join(', '),
+        'Not all extensions initialized: ' + remaining.join(', '),
       );
     }
   }

--- a/packages/tree-sitter/src/parser.ts
+++ b/packages/tree-sitter/src/parser.ts
@@ -1,6 +1,6 @@
 import { Language, Parser } from 'web-tree-sitter';
 
-let hasBeenLoaded = false;
+let initPromise: Promise<void> | null = null;
 
 type AssetLoad = (name: string) => Promise<Uint8Array<any>>;
 
@@ -8,17 +8,35 @@ interface Options {
   assetLoad: AssetLoad;
 }
 
+// Initialise the runtime once. A shared promise (not a boolean flag flipped
+// before init resolves) keeps concurrent callers from constructing a Parser
+// before init() completes on iOS/WKWebView.
+function ensureInitialized(assetLoad: AssetLoad): Promise<void> {
+  if (!initPromise) {
+    initPromise = (async () => {
+      const module = {
+        wasmBinary: await assetLoad('tree-sitter/web-tree-sitter.wasm'),
+        // Avoid web-tree-sitter's import.meta.url fallback, which throws
+        // "Invalid scheme" in an iOS Cordova WKWebView. Never fetched here
+        // because wasmBinary is provided.
+        locateFile(path: string) {
+          return path;
+        },
+      };
+      await Parser.init(module);
+    })().catch((error) => {
+      initPromise = null;
+      throw error;
+    });
+  }
+  return initPromise;
+}
+
 export async function createParser(
   wasmUint8Array: Uint8Array,
   { assetLoad }: Options,
 ): Promise<Parser> {
-  if (!hasBeenLoaded) {
-    hasBeenLoaded = true;
-    const module = {
-      wasmBinary: await assetLoad('tree-sitter/web-tree-sitter.wasm'),
-    };
-    await Parser.init(module);
-  }
+  await ensureInitialized(assetLoad);
   const parser = new Parser();
   const language = await Language.load(wasmUint8Array);
   parser.setLanguage(language);

--- a/utils/hooks/pre-push
+++ b/utils/hooks/pre-push
@@ -13,7 +13,14 @@ else
 fi
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
-COMMITS=$(git log origin/$BRANCH..HEAD --pretty=format:"%s")
+# In CI the checkout is a detached HEAD, so "origin/$BRANCH" resolves to
+# "origin/HEAD" (unset) and the range is ambiguous. Only diff against the
+# upstream branch when it actually exists; otherwise skip the range check.
+if [ "$BRANCH" != "HEAD" ] && git rev-parse --verify --quiet "origin/$BRANCH" >/dev/null; then
+  COMMITS=$(git log "origin/$BRANCH..HEAD" --pretty=format:"%s")
+else
+  COMMITS=""
+fi
 
 TRIVIAL_REGEXES=(
   "(fix|chore).*(typo|wip)"
@@ -21,14 +28,15 @@ TRIVIAL_REGEXES=(
 
 INVALID=0
 
-for msg in $COMMITS; do
+while IFS= read -r msg; do
+  [ -z "$msg" ] && continue
   for pattern in "${TRIVIAL_REGEXES[@]}"; do
     if echo "$msg" | grep -Ei "$pattern" >/dev/null; then
       echo -e "${RED}Trivial commit detected: '$msg'${NC}"
       INVALID=1
     fi
   done
-done
+done <<< "$COMMITS"
 
 if [ $INVALID -eq 1 ]; then
   echo "Please squash/fixup trivial commits before pushing."


### PR DESCRIPTION
Closes #101

## Summary

Fixes three iOS-only failures that prevented the Kerebron editor from loading in an iOS Cordova / WKWebView (JavaScriptCore) environment. All three reproduce deterministically on iOS while desktop V8/Chromium happens to avoid them, so they were only surfaced by on-device testing.

## Changes

### 1. `ExtensionManager` — non-iterable extensions (`{} is not iterable`)
iOS JSC threw `TypeError: {} is not iterable` from `setupExtensions`/`ExtensionManager`. Added a `toArraySafe()` helper (prefers `.forEach` for `Set`/`Map`, falls back to `Array.from`, otherwise warns and returns `[]`) and applied it at every iteration site, and replaced `Map`/`Set` `for...of` loops with `.forEach`.

### 2. `createParser` — `cannot construct a Parser before calling init()`
A boolean `hasBeenLoaded` flag was flipped to `true` **before** `Parser.init()` resolved, so a concurrent `createParser` call skipped initialization and reached `new Parser()` before the runtime was ready. Replaced the flag with a shared `initPromise` that every caller awaits (reset on failure to allow retry).

### 3. `createParser` — `Invalid scheme`
web-tree-sitter's `findWasmBinary()` still runs even when `wasmBinary` is supplied; without a `locateFile` it falls back to `new URL('web-tree-sitter.wasm', import.meta.url)`, which throws `Invalid scheme` inside an iOS Cordova WKWebView. We now pass a `locateFile` that returns the asset name. Because `wasmBinary` is already provided, the returned path is never fetched.

### CI
The `pull_request` commit-message lint and the `pre-push` hook iterated `$(git log ...)` unquoted, so each word of a subject was validated separately and no conventional-commit subject with spaces could pass; the pre-push hook additionally used `origin/$BRANCH`, which resolves to the ambiguous `origin/HEAD` under a detached-HEAD CI checkout. Both now iterate messages line by line, and the hook skips the range check when the upstream branch is unavailable.

## Testing
- Verified on an iOS simulator build: the editor now opens, typing/saving work, and existing markdown content loads into the rich editor (previously it silently fell back to plain text).
- No behavior change on desktop.